### PR TITLE
add Cisco IOS XR , Cisco IOS XE support

### DIFF
--- a/cpustat.go
+++ b/cpustat.go
@@ -15,6 +15,9 @@ func CpuUtilization(ip, community string, timeout, retry int) (int, error) {
 		oid = "1.3.6.1.4.1.9.9.305.1.1.1.0"
 	case "Cisco":
 		oid = "1.3.6.1.4.1.9.9.109.1.1.1.1.7.1"
+	case "Cisco_IOS_XE","Cisco_IOS_XR":
+		oid = "1.3.6.1.4.1.9.9.109.1.1.1.1.7"
+		method = "getnext"
 	case "Huawei":
 		oid = "1.3.6.1.4.1.2011.5.25.31.1.1.1.1.5"
 		return getH3CHWcpumem(ip, community, oid, timeout, retry)

--- a/descrstat.go
+++ b/descrstat.go
@@ -28,7 +28,13 @@ func SysVendor(ip, community string, timeout int) (string, error) {
 	}
 
 	if strings.Contains(sysDescrLower, "cisco ios") {
-		return "Cisco", err
+		if strings.Contains(sysDescr,"IOS-XE Software") {
+			return "Cisco_IOS_XE", err
+		}else if strings.Contains(sysDescr,"Cisco IOS XR"){
+			return "Cisco_IOS_XR", err
+		}else{
+			return "Cisco", err
+		}
 	}
 
 	if strings.Contains(sysDescrLower, "h3c") {

--- a/sw_test.go
+++ b/sw_test.go
@@ -6,58 +6,28 @@ import (
 )
 
 const (
-	ip        = "172.16.114.129"
+	ip        = "10.10.23.1"
 	community = "public"
-	oid       = "1.3.6.1.2.1.1.5.0"
-	timeout   = 1
+	oid       = "1.3.6.1.4.1.2011.5.25.31.1.1.1.1.5"
+	timeout   = 5
 	method    = "get"
+	retry     = 5
 )
 
-func Test_ListIfStats(t *testing.T) {
-	//	onlyPrefix := []string{"eth"}
-	onlyPrefix := []string{}
 
-	if np, err := ListIfStats(ip, community, timeout, onlyPrefix); err != nil {
-		t.Error(err)
-	} else {
-		fmt.Println("ListIfStats :", np)
-	}
-}
 
-func Test_ListIfName(t *testing.T) {
-	if np, err := ListIfName(ip, community, timeout); err != nil {
-		t.Error(err)
-	} else {
-		fmt.Println("ListIfName :", np)
-	}
-}
 
-func Test_ListIfHCInOctets(t *testing.T) {
-	if np, err := ListIfHCInOctets(ip, community, timeout); err != nil {
-		t.Error(err)
-	} else {
-		fmt.Println("ListIfHCInOctet :", np)
-	}
-}
-
-func Test_ListIfHCOutOctets(t *testing.T) {
-	if np, err := ListIfHCOutOctets(ip, community, timeout); err != nil {
-		t.Error(err)
-	} else {
-		fmt.Println("ListIfHCOutOctet :", np)
-	}
-}
 
 func Test_CpuUtilization(t *testing.T) {
-	if np, err := CpuUtilization(ip, community, timeout); err != nil {
+	if np, err := CpuUtilization(ip, community, timeout, retry); err != nil {
 		t.Error(err)
 	} else {
-		fmt.Println("CpuUtilization :", np)
+		t.Log("CpuUtilization :",np)
 	}
 }
 
 func Test_MemUtilization(t *testing.T) {
-	if np, err := MemUtilization(ip, community, timeout); err != nil {
+	if np, err := MemUtilization(ip, community, timeout, retry); err != nil {
 		t.Error(err)
 	} else {
 		fmt.Println("MemUtilization :", np)
@@ -69,6 +39,9 @@ func Test_RunSnmp(t *testing.T) {
 		t.Error(err)
 	} else {
 		fmt.Println("Test_RunSnmp :", np)
+		for _,v := range np{
+			fmt.Println("value:",v.Value.(int))
+		}
 	}
 }
 
@@ -88,6 +61,24 @@ func Test_SysVendor(t *testing.T) {
 	}
 }
 
+func Test_ListIfStats(t *testing.T) {
+	ignoreIface := []string{"VLAN","VL","Vl"}
+	ignorePkt := true
+	if np, err := ListIfStats(ip, community, timeout, ignoreIface, retry,ignorePkt); err != nil {
+		t.Error(err)
+	} else {
+	fmt.Println("value:", np)
+        }
+}
+func Test_ListIfStatsSnmpWalk(t *testing.T) {
+        ignoreIface := []string{"VLAN","VL","Vl"}
+        ignorePkt := true
+        if np, err := ListIfStatsSnmpWalk(ip, community, timeout, ignoreIface, retry,ignorePkt); err != nil {
+                t.Error(err)
+        } else {
+        fmt.Println("value:", np)
+        }
+}
 func Test_SysModel(t *testing.T) {
 	if np, err := SysModel(ip, community, timeout); err != nil {
 		t.Error(err)


### PR DESCRIPTION
增加了Cisco IOS XR和Cisco IOS XE的支持
这两个os里，cpu的oid似乎都不固定了，所以用getnext取第一个cpu的值。
测试型号，ASR9K，Cisco IOS XR Software, Version 5.3.0
测试型号，WS-C4507R+E ，Cisco IOS XE Software, Version 15.0
